### PR TITLE
Check if Gutenberg is installed before to register our block.

### DIFF
--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -28,6 +28,10 @@ function wp_js_plugin_starter_url( $path ) {
  * @since 1.0.0
  */
 function wp_js_plugin_starter_register_block() {
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+
 	wp_register_script(
 		'wp-js-plugin-starter',
 		wp_js_plugin_starter_url( 'dist/index.js' ),


### PR DESCRIPTION
This should avoid fatal errors when one installs and activate the starter plugin before Gutenberg gets activated on the site.