### PR TITLE
Since Gutenberg 4.5 Block scripts need to be registered in the footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-js-plugin-starter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Just another WordPress plugin starter",
   "main": "src/index.js",
   "private": true,

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -31,7 +31,7 @@ function wp_js_plugin_starter_register_block() {
 	wp_register_script(
 		'wp-js-plugin-starter',
 		wp_js_plugin_starter_url( 'dist/index.js' ),
-		array( 'wp-blocks' ),
+		array( 'wp-blocks', 'wp-element' ),
 		'1.0.1'
 	);
 

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP JS Plugin Starter
  * Plugin URI: https://github.com/youknowriad/wp-js-plugin-starter
  * Description: Just another WordPress plugin starter
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Riad Benguella
  *
  * @package wp-js-plugin-starter
@@ -31,7 +31,9 @@ function wp_js_plugin_starter_register_block() {
 	wp_register_script(
 		'wp-js-plugin-starter',
 		wp_js_plugin_starter_url( 'dist/index.js' ),
-		array( 'wp-element' )
+		array( 'wp-element' ),
+		'1.0.1',
+		true
 	);
 
 	register_block_type( 'wp-js-plugin-starter/hello-world', array(

--- a/wp-js-plugin-starter.php
+++ b/wp-js-plugin-starter.php
@@ -31,13 +31,12 @@ function wp_js_plugin_starter_register_block() {
 	wp_register_script(
 		'wp-js-plugin-starter',
 		wp_js_plugin_starter_url( 'dist/index.js' ),
-		array( 'wp-element' ),
-		'1.0.1',
-		true
+		array( 'wp-blocks' ),
+		'1.0.1'
 	);
 
 	register_block_type( 'wp-js-plugin-starter/hello-world', array(
-			'editor_script' => 'wp-js-plugin-starter',
+		'editor_script' => 'wp-js-plugin-starter',
 	) );
 }
 


### PR DESCRIPTION
Hi Riad,

I was testing your plugin and found this JavaScript error:
`Uncaught TypeError: Cannot read property 'registerBlockType' of undefined`

As I had the same issue with my own blocks and resolved it making sure JavaScript was registered into the footer, I thought you'd be interesting to update/fix this very usefull plugin too 😉 

👋 
